### PR TITLE
v3.0.1

### DIFF
--- a/data/infinity_barrel/function/destroy_infinity_barrel.mcfunction
+++ b/data/infinity_barrel/function/destroy_infinity_barrel.mcfunction
@@ -4,12 +4,13 @@
 
 execute as @s run data modify storage infinity_barrel: storage_item set from entity @s Item
 
-execute as @s if score @s IB_data < $64 IB_data store result storage infinity_barrel: storage_item.count byte 1 run scoreboard players get @s IB_data
+execute as @s if score @s IB_data < $64 IB_data store result storage infinity_barrel: storage_item.count int 1 run scoreboard players get @s IB_data
 execute as @s if score @s IB_data < $64 IB_data run scoreboard players set @s IB_data 0
-execute as @s if score @s IB_data >= $64 IB_data store result storage infinity_barrel: storage_item.count byte 1 run scoreboard players get $64 IB_data
+execute as @s if score @s IB_data >= $64 IB_data store result storage infinity_barrel: storage_item.count int 1 run scoreboard players get $64 IB_data
 execute as @s if score @s IB_data >= $64 IB_data run scoreboard players remove @s IB_data 64
 
-execute as @s at @s run function infinity_barrel:send_item with storage infinity_barrel: {}
+execute as @s at @s unless data storage infinity_barrel: {storage_item:{count:0}} run function infinity_barrel:send_item with storage infinity_barrel: {}
+
 
 
 execute if score @s IB_data matches 1.. run function infinity_barrel:destroy_infinity_barrel

--- a/data/infinity_barrel/function/load.mcfunction
+++ b/data/infinity_barrel/function/load.mcfunction
@@ -28,5 +28,5 @@ scoreboard players set $max_storage IB_data 65536
 #村人の削除
 execute as @e[type=minecraft:villager,tag=infinity_barrel] run data merge entity @s {Pos:[0.0d, -65.0d, 0.0d],Health:0f,DeathTime:18s}
 
-tellraw @a ["",{"text":"[Infinity Barrel]","color":"aqua"},{"text":" Ver.3.0.0\n","color":"green"},{"text":"Produced by ","color":"gray"},{"text":"yuton502","color":"white"}]
+tellraw @a ["",{"text":"[Infinity Barrel]","color":"aqua"},{"text":" Ver.3.0.1\n","color":"green"},{"text":"Produced by ","color":"gray"},{"text":"yuton502","color":"white"}]
 

--- a/data/infinity_barrel/function/tick.mcfunction
+++ b/data/infinity_barrel/function/tick.mcfunction
@@ -16,4 +16,4 @@ execute as @a at @s as @e[type=minecraft:interaction,tag=infinity_barrel,distanc
 execute as @a at @s if entity @e[type=minecraft:item_frame,tag=infinity_barrel,distance=..3.5] anchored eyes run function infinity_barrel:watch_effect
 
 #Infinity Barrelを持っていたら移動速度低下を付与
-execute as @a[predicate=infinity_barrel:have_infinity_barrel] at @s run summon area_effect_cloud ~ ~ ~ {Radius:0f,Duration:6,Age:4,Effects:[{Id:2b,Amplifier:1b,Duration:2,ShowParticles:0b}]}
+execute as @a[predicate=infinity_barrel:have_infinity_barrel] at @s run summon area_effect_cloud ~ ~ ~ {Radius:0f,Duration:6,Age:4,potion_contents:{custom_effects:[{id:"minecraft:slowness",duration:2,amplifier:1,show_particles:0b,show_icon:1}]}}

--- a/data/infinity_barrel/predicate/have_infinity_barrel.json
+++ b/data/infinity_barrel/predicate/have_infinity_barrel.json
@@ -3,6 +3,6 @@
   "entity": "this",
   "predicate": {
     "type": "minecraft:player",
-    "nbt": "{Inventory:[{id:\"minecraft:item_frame\",tag:{\"minecraft:entity_data\":{Tags:[\"Carrying_Infinity_Barrel\"]}}}]}"
+    "nbt": "{Inventory:[{id:\"minecraft:item_frame\",components:{\"minecraft:entity_data\":{Tags:[\"Carrying_Infinity_Barrel\"]}}}]}"
   }
 }


### PR DESCRIPTION
Minecraft Ver.1.21対応
前提データパックなし

 ## 変更点 / Changes
- 収納数が0の状態でInfinity Barrelを破壊すると、アイテムが1つ複製できてしまうバグを修正<br>Fixed the bug that 1 item can replicate, if breaking Infinity Barrel when 0 item stored.
- 構文変更し忘れていた箇所の修正<br>Supported 1.21 syntaxes that were not supported in 1.21.